### PR TITLE
Fix docker production service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:14
 
-WORKDIR /usr/src
+RUN mkdir /app
+WORKDIR /app
 
 COPY ./server/package*.json ./server/
 COPY ./client/package*.json ./client/
@@ -8,8 +9,6 @@ COPY ./client/package*.json ./client/
 RUN npm install --prefix ./client
 RUN npm install --prefix ./server
 
-ADD . .
-
 EXPOSE 3001
 
-CMD npm run start --prefix ./server
+ENTRYPOINT ["npm", "run", "start", "--prefix", "./server"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ In a law firm, one of the weekly workloads consists of monitoring lawsuits, chec
 
 A report (in  portuguese) with an in depth explanation of the application and the problem it aims to solve is found in `/relatorio_primeiro_entregavel.pdf`.
 
-## Run this app
+## Running this app
 
 ### As a node package
 
@@ -14,12 +14,12 @@ Go to the `/client/src directory`, then execute
 
 and the application will be available at `localhost:3000`.
 
-### Using the Docker container
+### Using the Docker production image
 After starting the `Docker daemon`, simply run
 
-`$ docker-compose up` 
+`$ docker-compose up application` 
 
-and the application will be available at `localhost:8080`.
+and the application will be available at `localhost:3001`.
 
 ## Typical usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-    client:
+    dev-client:
         build:
             context: ./client
             dockerfile: Dockerfile.dev
@@ -9,16 +9,16 @@ services:
         container_name: dev-client
         volumes:
             - ./client:/usr/src/app
-            - ./client/node_modules:/usr/src/app/node_modules
 
     application:
         build:
             context: ./
-            dockerfile: Dockerfile.dev
+            dockerfile: Dockerfile
         ports:
             - "3001:3001"
         container_name: application
         volumes:
-            - ./client:/usr/src/client
-            - ./server:/usr/src/app
-            - ./server/node_modules:/usr/src/app/node_modules
+            - /app/client/node_modules
+            - /app/server/node_modules
+            - ./client:/app/client
+            - ./server:/app/server


### PR DESCRIPTION
## Proposta

Esse MR corrige a configuração do serviço docker de produção, excluindo a necessidade de se rodar `npm install` fora do container.

## Status do PR
- [x] Testes manuais
- [ ] Testes unitários
- [ ] Testes de integração
- [ ] Documentação criada

## Comentário para revisores


## Comentários para teste
